### PR TITLE
docs: add central OctoAcme project management README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,49 @@
+<!--
+Docs index for the OctoAcme playbook in this repository.
+This file provides a short overview and links to the guides in this folder.
+-->
+
+# OctoAcme Docs
+
+This folder contains the OctoAcme playbook: practical guides and reference
+materials for executing, planning, and managing OctoAcme projects.
+
+Use these guides as a lightweight, repeatable set of practices for
+project initiation, planning, execution, risk management, retrospectives,
+and release/deployment.
+
+**Included guides**
+- `octoacme-project-initiation.md` - Steps and checklist for starting a new project.
+- `octoacme-project-planning.md` - Planning templates, milestones and timelines.
+- `octoacme-project-management-overview.md` - Roles, responsibilities and cadence.
+- `octoacme-execution-and-tracking.md` - How to run work, track progress, and report.
+- `octoacme-risks-and-communication.md` - Risk register guidance and communication plans.
+- `octoacme-retrospective-and-continuous-improvement.md` - Retro templates and follow-ups.
+- `octoacme-release-and-deployment.md` - Release checklist and deployment guidance.
+- `octoacme-roles-and-personas.md` - Role descriptions and recommended staffing.
+
+**How to use these docs**
+
+- Read the `octoacme-project-initiation.md` when starting a new project to gather
+	context, stakeholders, and success criteria.
+- Use `octoacme-project-planning.md` and `octoacme-project-management-overview.md`
+	to pick planning artefacts and define the project's cadence.
+- Follow `octoacme-execution-and-tracking.md` for day-to-day tracking and reporting.
+- Keep a lightweight risk register using `octoacme-risks-and-communication.md`.
+- Run retrospectives using the template in `octoacme-retrospective-and-continuous-improvement.md`.
+
+**Contributing**
+
+- Found an error or have an improvement? Edit the relevant file and open a PR.
+- When adding a new guide, name it `octoacme-<topic>.md` and add a one-line
+	entry to this README.
+
+**License & contact**
+
+- Repository license: see the project `LICENSE` file.
+- Questions or suggestions: open an issue or contact the repository maintainers.
+
+---
+
+Thanks for using the OctoAcme playbook — use these guides to make project
+work predictable, repeatable and continuously improving.


### PR DESCRIPTION
This PR adds docs/README.md to provide a single entry point for OctoAcme project management processes. The README:

- Summarizes the lifecycle (Initiation, Planning, Execution, Release, Retrospective)
- Notes core roles and communication/quality practices
- Links to all process documents in the docs/ folder
- Improves discoverability and onboarding for new team members

Closes #2